### PR TITLE
ST-1118 added prophet possibility

### DIFF
--- a/core/src/main/java/de/neofonie/styla/core/models/CloudServiceModel.java
+++ b/core/src/main/java/de/neofonie/styla/core/models/CloudServiceModel.java
@@ -27,8 +27,8 @@ public class CloudServiceModel {
     @Inject
     private Page currentPage;
 
-    public String getSeoApiUrl(ResourceResolver resourceResolver, Page contentRootPage) {
-        return getCloudServiceProperty(resourceResolver, contentRootPage);
+    public String getSeoApiUrl(final ResourceResolver resourceResolver, final Page page) {
+        return getCloudServiceProperty(resourceResolver, page, "seoApiUrl");
     }
 
     public String getSeoApiUrl() {
@@ -36,7 +36,15 @@ public class CloudServiceModel {
     }
 
     public String getScript() {
-        return getCloudServiceProperty("script");
+        final String script = getCloudServiceProperty("script");
+        LOGGER.debug(String.format("Found script: %s", script));
+        return script;
+    }
+
+    public String getClient(final ResourceResolver resourceResolver, final Page page) {
+        final String client = getCloudServiceProperty(resourceResolver, page, "client");
+        LOGGER.debug(String.format("Found client: %s", client));
+        return client;
     }
 
     private String getCloudServiceConfiguration(Page contentRootPage) {
@@ -72,14 +80,15 @@ public class CloudServiceModel {
         return propertyValue;
     }
 
-    private String getCloudServiceProperty(final ResourceResolver resourceResolver, final Page page) {
-        final String property = "seoApiUrl";
+    private String getCloudServiceProperty(final ResourceResolver resourceResolver,
+                                           final Page page,
+                                           final String property) {
         final String cloudServiceConfiguration = getCloudServiceConfiguration(page);
 
         if (StringUtils.isEmpty(cloudServiceConfiguration)) {
             final Page parentPage = page.getParent();
             if (parentPage != null) {
-                return getCloudServiceProperty(resourceResolver, parentPage);
+                return getCloudServiceProperty(resourceResolver, parentPage, property);
             }
             LOGGER.warn(String.format("Failed to get cloud service property: %s", property));
             return null;

--- a/core/src/main/java/de/neofonie/styla/core/models/CrawlerConfig.java
+++ b/core/src/main/java/de/neofonie/styla/core/models/CrawlerConfig.java
@@ -1,0 +1,32 @@
+package de.neofonie.styla.core.models;
+
+public class CrawlerConfig {
+
+    private String templateType;
+    private String contentRootPath;
+    private String siteRootPath;
+
+    public String getTemplateType() {
+        return templateType;
+    }
+
+    public void setTemplateType(String templateType) {
+        this.templateType = templateType;
+    }
+
+    public String getContentRootPath() {
+        return contentRootPath;
+    }
+
+    public void setContentRootPath(String contentRootPath) {
+        this.contentRootPath = contentRootPath;
+    }
+
+    public String getSiteRootPath() {
+        return siteRootPath;
+    }
+
+    public void setSiteRootPath(String siteRootPath) {
+        this.siteRootPath = siteRootPath;
+    }
+}

--- a/core/src/main/java/de/neofonie/styla/core/models/PathEntry.java
+++ b/core/src/main/java/de/neofonie/styla/core/models/PathEntry.java
@@ -1,0 +1,40 @@
+package de.neofonie.styla.core.models;
+
+import java.io.Serializable;
+
+/**
+ * PathEntry class is a representation for the response
+ * of https://paths.styla.com/v1/delta/ci-oxid-nle
+ *
+ * @author Sebastian Sachtleben
+ */
+public class PathEntry implements Serializable {
+
+    private String name;
+    private String path;
+    private PathEntryType type;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(final String path) {
+        this.path = path;
+    }
+
+    public PathEntryType getType() {
+        return type;
+    }
+
+    public void setType(final PathEntryType type) {
+        this.type = type;
+    }
+}

--- a/core/src/main/java/de/neofonie/styla/core/models/PathEntryType.java
+++ b/core/src/main/java/de/neofonie/styla/core/models/PathEntryType.java
@@ -1,0 +1,16 @@
+package de.neofonie.styla.core.models;
+
+public enum PathEntryType {
+    PAGE("PAGE"),
+    MODULE("MODULE");
+
+    private String value;
+
+    PathEntryType(final String value) {
+        this.value = value;
+    }
+
+    public String geValue() {
+        return value;
+    }
+}

--- a/core/src/main/java/de/neofonie/styla/core/utils/SeoUtils.java
+++ b/core/src/main/java/de/neofonie/styla/core/utils/SeoUtils.java
@@ -28,11 +28,13 @@ public class SeoUtils {
 
     /**
      * Writes SEO information into a resource
-     * @param seo
-     * @param resource
+     *
      * @return returns true if the resource has been modified.
      */
-    public static boolean writeSeoToResource(final Seo seo, final Resource resource) {
+    public static boolean writeSeoToResource(final Resource resource,
+                                             final Seo seo,
+                                             final String path,
+                                             final String seoBody) {
         if (resource == null || seo == null) {
             LOGGER.warn("Resource or seo is empty");
             return false;
@@ -49,7 +51,8 @@ public class SeoUtils {
         final Map<String, Object> properties = new HashMap<>();
 
         writeMetaTagsToProperties(seo, properties);
-        properties.put("stylaSeoBody", seo.getHtml().getBody());
+        properties.put("stylaPath", path);
+        properties.put("stylaSeoBody", seoBody);
 
         if (!isUpdated(modifiableValueMap, properties)) {
             return false;

--- a/ui.apps/src/main/content/jcr_root/apps/acs/styla/components/stylapage/content.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs/styla/components/stylapage/content.jsp
@@ -1,11 +1,12 @@
 <%@page contentType="text/html"
             pageEncoding="utf-8"%><%
 %><%@include file="/libs/foundation/global.jsp"%><div>
- 
+
 <div>
-    <h3>Styla Settings</h3>   
+    <h3>Styla Settings</h3>
     <ul>
-        <li><div class="li-bullet"><strong>SEO API URL: </strong><%= xssAPI.encodeForHTML(properties.get("seoApiUrl", "")) %></div></li>
+        <li><div class="li-bullet"><strong>Client: </strong><%= xssAPI.encodeForHTML(properties.get("client", "")) %></div></li>
+        <li><div class="li-bullet"><strong>Seo Api Url: </strong><%= xssAPI.encodeForHTML(properties.get("seoApiUrl", "")) %></div></li>
         <li><div class="li-bullet"><strong>Script: </strong><%= xssAPI.encodeForHTML(properties.get("script", "")) %></div></li>
     </ul>
 </div>

--- a/ui.apps/src/main/content/jcr_root/apps/acs/styla/components/stylapage/dialog.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs/styla/components/stylapage/dialog.xml
@@ -11,17 +11,24 @@
                 jcr:primaryType="cq:Panel"
                 title="Config">
                 <items jcr:primaryType="cq:WidgetCollection">
+                    <client
+                            jcr:primaryType="cq:Widget"
+                            fieldDescription="Styla Client Name"
+                            fieldLabel="Client Name"
+                            xtype="textfield"
+                            name="./client"
+                            title="Client Name"/>
                     <seoApiUrl
                         jcr:primaryType="cq:Widget"
-                        fieldDescription="The url for the styla SEO API. Use placeholder $URL and $LANG, e.g. http://seoapi.styla.com/clients/CLIENT?url=story/$URL&amp;lang=$LANG"
-                        fieldLabel="SEO API URL"
+                        fieldDescription="Styla Seo Api Url - Use placeholder $URL and $LANG, e.g. http://seoapi.styla.com/clients/CLIENT?url=story/$URL&amp;lang=$LANG"
+                        fieldLabel="Seo Api Url"
                         xtype="textfield"
                         name="./seoApiUrl"
-                        title="SEO API URL"/>
+                        title="Seo Api Url"/>
                     <script
                         jcr:primaryType="cq:Widget"
-                        fieldDescription="The JS script for the styla Content Hub"
-                        fieldLabel="SCRIPT"
+                        fieldDescription="Styla JS Script"
+                        fieldLabel="Script"
                         xtype="textfield"
                         name="./script"
                         title="Script"/>

--- a/ui.apps/src/main/content/jcr_root/apps/styla/components/structure/emptypage/body.html
+++ b/ui.apps/src/main/content/jcr_root/apps/styla/components/structure/emptypage/body.html
@@ -1,17 +1,1 @@
-<div id="stylaMagazine">
-    ${properties.stylaSeoBody @ context='html'}
-    <script>
-        if ( !( window.location.host.indexOf( 'google' ) > -1 ) )
-        {
-            document.getElementById('stylaContentSEO').parentNode.removeChild(document.getElementById('stylaContentSEO'));
-
-            var elements = document.querySelectorAll("[data-no-hydration='true']");
-            for (var i = 0; i < elements.length; ++i) {
-                var last, node = elements[i];
-                while (last = node.lastChild) {
-                    node.removeChild(last);
-                }
-            }
-        }
-    </script>
-</div>
+${properties.stylaSeoBody @ context='unsafe'}

--- a/ui.apps/src/main/content/jcr_root/apps/styla/config.author/de.neofonie.styla.core.jobs.SeoImportService-7eacab70-6264-4047-936e-ae1909176885.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/styla/config.author/de.neofonie.styla.core.jobs.SeoImportService-7eacab70-6264-4047-936e-ae1909176885.xml
@@ -2,4 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="sling:OsgiConfig"
           scheduler.expression="0\ *\ *\ ?\ *\ *"
-          contentRootPath="/content/styla/en"/>
+          contentRootPath="/content/styla/en"
+          siteRootPath=""/>

--- a/ui.apps/src/main/content/jcr_root/etc/cloudservices/styla/sample/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/etc/cloudservices/styla/sample/.content.xml
@@ -11,6 +11,7 @@
         jcr:primaryType="cq:PageContent"
         jcr:title="Client sample"
         sling:resourceType="acs/styla/components/stylapage"
-        script="//client-scripts.stage.eu.magalog.net/scripts/clients/aem-test.js"
+        client="aem-test"
+        script="https://engine.styla.com/prophet-stage.js"
         seoApiUrl="http://seoapi.stage.eu.magalog.net/clients/aem-test?url=$URL"/>
 </jcr:root>


### PR DESCRIPTION
- Add new client field to cloud config
- If client is set we use data-styla-client tag instead of id#stylaMagazine
- Within the seo importer if the client is set make a request to paths endpoint
- Save the area path in the page properties
- if area path is set use data-styla-content
- Iterate over pages and create page in aem if not exists (not fully done yet)